### PR TITLE
Fixed usage of npm plugins on Ubuntu Phone

### DIFF
--- a/cordova-lib/src/plugman/platforms/ubuntu.js
+++ b/cordova-lib/src/plugman/platforms/ubuntu.js
@@ -71,7 +71,13 @@ module.exports = {
             var src = String(fs.readFileSync(plugins));
 
             src = src.replace('INSERT_HEADER_HERE', '#include "plugins/' + plugin_id + '/' + path.basename(obj.src) +'"\nINSERT_HEADER_HERE');
-            var class_name = plugin_id.match(/\.[^.]+$/)[0].substr(1);
+            var class_name;
+            var class_prefix = "cordova-plugin-";
+            if(plugin_id.indexOf(class_prefix) === 0) {
+                class_name = plugin_id.substr(class_prefix.length);
+            } else {
+                class_name = plugin_id.match(/\.[^.]+$/)[0].substr(1);
+            }
             class_name = toCamelCase(class_name);
             src = src.replace('INSERT_PLUGIN_HERE', 'INIT_PLUGIN(' + class_name + ');INSERT_PLUGIN_HERE');
 


### PR DESCRIPTION
Plugins with an id in the form of cordova-plugin-<name> could be added to the ubuntu platform. Quick and dirty fix to avoid this problem, maybe someone with more knowledge of the project can implement a better solution.
